### PR TITLE
Add Visible field to Node struct

### DIFF
--- a/ipc/tree.go
+++ b/ipc/tree.go
@@ -181,6 +181,7 @@ type Node struct {
 	Nodes              []Node           `json:"nodes"`
 	Active             bool             `json:"active,omitempty"`
 	Primary            bool             `json:"primary,omitempty"`
+	Visible            bool             `json:"visible,omitempty"`
 	Make               string           `json:"make,omitempty"`
 	Model              string           `json:"model,omitempty"`
 	Serial             string           `json:"serial,omitempty"`


### PR DESCRIPTION
This adds a Visible field to Node. FloatingNodes already has this field.

Example of a node with Visible set to true:

```
Node: ipc.Node{ID:20, Name:"gosway/ipc/tree.go at master · Difrex/gosway — Mozilla Firefox", Rect:ipc.Rect{X:0, Y:24, Width:1147, Height:1416}, Focused:true, Focus:[]int{}, Border:"pixel", CurrentBorderWidth:1, Layout:"none", Orientation:"none", Percent:1, WindowRect:ipc.WindowRect{X:1, Y:1, Width:1145, Height:1414}, DecoRect:ipc.DecoRect{X:0, Y:0, Width:0, Height:0}, Geometry:ipc.Geometry{X:0, Y:0, Width:1920, Height:1029}, Window:interface {}(nil), Urgent:false, FloatingNodes:[]ipc.Node{}, Sticky:false, Type:"con", Nodes:[]ipc.Node{}, Active:false, Primary:false, Visible:true, Make:"", Model:"", Serial:"", Scale:0, Transform:"", CurrentWorkspace:"", Modes:[]ipc.Modes(nil), CurrentMode:ipc.CurrentMode{Width:0, Height:0, Refresh:0}, Representation:"", WindowProperties:ipc.WindowProperties{Class:"", Instance:"", Title:"", TransientFor:interface {}(nil), WindowRole:""}}
```